### PR TITLE
Fixed a missing cast in WorldPackets::Garrison::GarrisonStartMissionResult::Write()

### DIFF
--- a/src/server/game/Server/Packets/GarrisonPackets.cpp
+++ b/src/server/game/Server/Packets/GarrisonPackets.cpp
@@ -470,7 +470,7 @@ WorldPacket const* WorldPackets::Garrison::GarrisonStartMissionResult::Write()
     _worldPacket << FailReason;
     _worldPacket << Mission;
 
-    _worldPacket << Followers.size();
+    _worldPacket << uint32(Followers.size());
     for (uint64 followerDbID : Followers)
         _worldPacket << followerDbID;
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Casting Followers.size() to uint32 in WorldPackets::Garrison::GarrisonStartMissionResult::Write()


**Issues addressed:** Closes #  No issue opened, this does however break the build on macos


**Tests performed:** It builds


**Known issues and TODO list:** (add/remove lines as needed)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
